### PR TITLE
Add permissions mechanism

### DIFF
--- a/salsah2xml.py
+++ b/salsah2xml.py
@@ -1146,6 +1146,8 @@ class Salsah:
             restype = upper_camel_case(tmp[1])
         else:
             restype = upper_camel_case(resource["resdata"]["restype_name"])
+
+        # Add resource nodes to XML
         resnode = etree.Element('resource', {
             'restype': ":" + restype,
             'id': lower_camel_case(restype) + "_" + resource["resdata"]["res_id"],
@@ -1181,6 +1183,7 @@ class Salsah:
         for propname in resource["props"]:
             propnode = self.process_property(propname, resource["props"][propname])  # process_property()
             if propnode is not None:
+                # Add property node to resource node in XML
                 resnode.append(propnode)
         self.root.append(resnode)  # Das geht in die Resourcen
         print('Resource added. Id=' + resource["resdata"]["res_id"], flush=True)
@@ -1226,8 +1229,8 @@ def program(args):
     parser.add_argument("-p", "--password", help="The password for login")
     parser.add_argument("-P", "--project", help="Shortname or ID of project")
     parser.add_argument("-s", "--shortcode", default='XXXX', help="Knora-shortcode of project")
-    parser.add_argument("-n", "--nrows", type=int, help="Number of records to get, -1 to get all")
     parser.add_argument("-S", "--start", type=int, help="Start at record with given number")
+    parser.add_argument("-n", "--nrows", type=int, help="Number of records to get, -1 to get all")
     parser.add_argument("-F", "--folder", default="-", help="Output folder")
     parser.add_argument("-r", "--resptrs_file", help="List of resptrs targets")
     parser.add_argument("-c", "--permissions_file", help="List of permission configurations")

--- a/salsah2xml.py
+++ b/salsah2xml.py
@@ -394,17 +394,17 @@ class Salsah:
         self.vocabulary = vocabulary['shortname']
 
         # Get project selections
-        project['lists'] = self.get_selections_of_vocabulary(vocabulary['shortname'])
+        project['lists'] = self.get_selections_of_vocabulary(self.vocabulary)
 
         # ToDo: not yet implemented in create_ontology
         # if vocabulary.get('description') is not None and vocabulary['description']:
         #    project['ontologies']['comment'] = vocabulary['description']
 
-        prop, res = self.get_resourcetypes_of_vocabulary(vocabulary['shortname'])
+        prop, res = self.get_resourcetypes_of_vocabulary(self.vocabulary)
 
         project['ontologies'] = [{
-            'name': vocabulary['shortname'],
-            'label': vocabulary['longname'],
+            'name': self.vocabulary,
+            'label': self.vocabulary,
             'properties': prop,
             'resources': res
         }]

--- a/salsah2xml.py
+++ b/salsah2xml.py
@@ -1271,14 +1271,18 @@ def program(args):
 
     resptrs: Dict = {}
     if args.resptrs_file is not None:
-        tree = etree.parse(args.resptrs_file)
-        root = tree.getroot()
-        for restype in root:
-            restype_name = restype.attrib["name"].strip()
-            props: Dict = {}
-            for prop in restype:
-                props[prop.attrib["name"]] = prop.text.strip()
-            resptrs[restype.attrib["name"]] = props
+        resptrs_tree = etree.parse(args.resptrs_file, parser)
+        resptrs_root = resptrs_tree.getroot()
+        if resptrs_root.find('resource') is not None:
+            for restype in resptrs_root.findall('resource'):
+                restype_name = restype.attrib["name"].strip()
+                props: Dict = {}
+                for prop in restype:
+                    props[prop.attrib["name"]] = prop.text.strip()
+                resptrs[restype_name] = props
+        else:
+            print('No resources specified in given file: "{}"!'.format(args.resptrs_file))
+
     permissions: Dict = {}
     if args.permissions_file is not None:
         permissions_tree = etree.parse(args.permissions_file, parser)

--- a/webern-permissions.xml
+++ b/webern-permissions.xml
@@ -1,0 +1,26 @@
+<permissionsList vocabulary="webern">
+    <permissions id="awg-res-default">
+        <allow group="UnknownUser">V</allow>
+        <allow group="KnownUser">V</allow>
+        <allow group="Creator">D</allow>
+        <allow group="ProjectMember">D</allow>
+        <allow group="ProjectAdmin">CR</allow>
+    </permissions>
+    <permissions id="awg-res-internal">
+        <allow group="Creator">D</allow>
+        <allow group="ProjectMember">D</allow>
+        <allow group="ProjectAdmin">CR</allow>
+    </permissions>
+    <permissions id="awg-prop-default">
+        <allow group="UnknownUser">V</allow>
+        <allow group="KnownUser">V</allow>
+        <allow group="Creator">D</allow>
+        <allow group="ProjectMember">D</allow>
+        <allow group="ProjectAdmin">CR</allow>
+    </permissions>
+    <permissions id="awg-prop-internal">
+        <allow group="Creator">D</allow>
+        <allow group="ProjectMember">D</allow>
+        <allow group="ProjectAdmin">CR</allow>
+    </permissions>
+</permissionsList>


### PR DESCRIPTION
This PR adds a mechanism to include the project permission configurations to be applied to the resources and properties. The mechanism follows the approach of the resptrs, with the permission settings stored in a separate XML file. That allows for individual project-based specifications of permissions.

Please note: How the permissions will be applied to a specific resource or property still needs to be resolved (preferably in another PR).